### PR TITLE
Multipath Bugfix Changes

### DIFF
--- a/gonvme_tcp.go
+++ b/gonvme_tcp.go
@@ -322,7 +322,7 @@ func (nvme *NVMeTCP) nvmeDisconnect(target NVMeTarget) error {
 }
 
 // ListNamespaceDevices returns the NVMe namespace Device Paths and each output content
-func (nvme *NVMeTCP) ListNamespaceDevices() map[devicePathAndNamespace][]string {
+func (nvme *NVMeTCP) ListNamespaceDevices() map[DevicePathAndNamespace][]string {
 	exe := nvme.buildNVMeCommand([]string{"nvme", "list", "-o", "json"})
 
 	/* nvme list -o json
@@ -361,8 +361,8 @@ func (nvme *NVMeTCP) ListNamespaceDevices() map[devicePathAndNamespace][]string 
 	str := string(output)
 	lines := strings.Split(str, "\n")
 
-	var result []devicePathAndNamespace
-	var currentPathAndNamespace *devicePathAndNamespace
+	var result []DevicePathAndNamespace
+	var currentPathAndNamespace *DevicePathAndNamespace
 	var devicePath string
 	var namespace string
 
@@ -380,7 +380,7 @@ func (nvme *NVMeTCP) ListNamespaceDevices() map[devicePathAndNamespace][]string 
 			if len(strings.Split(line, ":")) >= 2 {
 				devicePath = strings.ReplaceAll(strings.TrimSpace(strings.Split(line, ":")[1]), "\"", "")
 
-				PathAndNamespace := devicePathAndNamespace{}
+				PathAndNamespace := DevicePathAndNamespace{}
 				PathAndNamespace.namespace = namespace
 				PathAndNamespace.devicePath = devicePath
 
@@ -395,12 +395,12 @@ func (nvme *NVMeTCP) ListNamespaceDevices() map[devicePathAndNamespace][]string 
 		result = append(result, *currentPathAndNamespace)
 	}
 
-	namespaceDevices := make(map[devicePathAndNamespace][]string)
+	namespaceDevices := make(map[DevicePathAndNamespace][]string)
 
 	for _, devicePathAndNamespace := range result {
 
-		devicePath = devicePathAndNamespace.devicePath
-		namespace = devicePathAndNamespace.namespace
+		devicePath = devicePathAndNamespace.DevicePath
+		namespace = devicePathAndNamespace.Namespace
 
 		exe := nvme.buildNVMeCommand([]string{"nvme", "list-ns", devicePath})
 		/* nvme list-ns /dev/nvme0n1

--- a/gonvme_tcp.go
+++ b/gonvme_tcp.go
@@ -381,8 +381,8 @@ func (nvme *NVMeTCP) ListNamespaceDevices() map[DevicePathAndNamespace][]string 
 				devicePath = strings.ReplaceAll(strings.TrimSpace(strings.Split(line, ":")[1]), "\"", "")
 
 				PathAndNamespace := DevicePathAndNamespace{}
-				PathAndNamespace.namespace = namespace
-				PathAndNamespace.devicePath = devicePath
+				PathAndNamespace.namespace = Namespace
+				PathAndNamespace.devicePath = DevicePath
 
 				if currentPathAndNamespace != nil {
 					result = append(result, *currentPathAndNamespace)

--- a/gonvme_tcp.go
+++ b/gonvme_tcp.go
@@ -321,7 +321,7 @@ func (nvme *NVMeTCP) nvmeDisconnect(target NVMeTarget) error {
 	return err
 }
 
-// ListNamespaceDevices returns the NVMe namespace Device Paths and each output content
+// ListNamespaceDevices returns the Device Paths and Namespace of each device and each output content
 func (nvme *NVMeTCP) ListNamespaceDevices() map[DevicePathAndNamespace][]string {
 	exe := nvme.buildNVMeCommand([]string{"nvme", "list", "-o", "json"})
 
@@ -397,6 +397,14 @@ func (nvme *NVMeTCP) ListNamespaceDevices() map[DevicePathAndNamespace][]string 
 
 	namespaceDevices := make(map[DevicePathAndNamespace][]string)
 
+	/* finding the namespaceDevices Output
+	{devicePath namespace} [namespaceId1 namespaceId2]
+	{/dev/nvme0n1 54} [0x36 0x37]
+	{/dev/nvme0n2 55} [0x36 0x37]
+	{/dev/nvme1n1 54} [0x36 0x37]
+	{/dev/nvme1n2 55} [0x36 0x37]
+	 */
+
 	for _, devicePathAndNamespace := range result {
 
 		devicePath = devicePathAndNamespace.DevicePath
@@ -436,6 +444,42 @@ func (nvme *NVMeTCP) GetNamespaceData(path string, namespaceID string) (string, 
 
 	exe := nvme.buildNVMeCommand([]string{"nvme", "id-ns", path, "--namespace", namespaceID})
 	cmd := exec.Command(exe[0], exe[1:]...)
+
+	/*
+	nvme id-ns /dev/nvme3n1 0x95
+	NVME Identify Namespace 149:
+	nsze    : 0x1000000
+	ncap    : 0x1000000
+	nuse    : 0x223b8
+	nsfeat  : 0xb
+	nlbaf   : 0
+	flbas   : 0
+	mc      : 0
+	dpc     : 0
+	dps     : 0
+	nmic    : 0x1
+	rescap  : 0xff
+	fpi     : 0
+	dlfeat  : 9
+	nawun   : 2047
+	nawupf  : 2047
+	nacwu   : 0
+	nabsn   : 2047
+	nabo    : 0
+	nabspf  : 2047
+	noiob   : 0
+	nvmcap  : 0
+	mssrl   : 0
+	mcl     : 0
+	msrc    : 0
+	anagrpid: 2
+	nsattr  : 0
+	nvmsetid: 0
+	endgid  : 0
+	nguid   : 507911ecda65a2498ccf0968009a5d07
+	eui64   : 0000000000000000
+	lbaf  0 : ms:0   lbads:9  rp:0 (in use)
+	 */
 
 	output, error := cmd.Output()
 	str := string(output)

--- a/gonvme_tcp.go
+++ b/gonvme_tcp.go
@@ -381,8 +381,8 @@ func (nvme *NVMeTCP) ListNamespaceDevices() map[DevicePathAndNamespace][]string 
 				devicePath = strings.ReplaceAll(strings.TrimSpace(strings.Split(line, ":")[1]), "\"", "")
 
 				PathAndNamespace := DevicePathAndNamespace{}
-				PathAndNamespace.namespace = Namespace
-				PathAndNamespace.devicePath = DevicePath
+				PathAndNamespace.Namespace = namespace
+				PathAndNamespace.DevicePath = devicePath
 
 				if currentPathAndNamespace != nil {
 					result = append(result, *currentPathAndNamespace)

--- a/gonvme_tcp.go
+++ b/gonvme_tcp.go
@@ -403,7 +403,7 @@ func (nvme *NVMeTCP) ListNamespaceDevices() map[DevicePathAndNamespace][]string 
 	{/dev/nvme0n2 55} [0x36 0x37]
 	{/dev/nvme1n1 54} [0x36 0x37]
 	{/dev/nvme1n2 55} [0x36 0x37]
-	 */
+	*/
 
 	for _, devicePathAndNamespace := range result {
 
@@ -446,40 +446,40 @@ func (nvme *NVMeTCP) GetNamespaceData(path string, namespaceID string) (string, 
 	cmd := exec.Command(exe[0], exe[1:]...)
 
 	/*
-	nvme id-ns /dev/nvme3n1 0x95
-	NVME Identify Namespace 149:
-	nsze    : 0x1000000
-	ncap    : 0x1000000
-	nuse    : 0x223b8
-	nsfeat  : 0xb
-	nlbaf   : 0
-	flbas   : 0
-	mc      : 0
-	dpc     : 0
-	dps     : 0
-	nmic    : 0x1
-	rescap  : 0xff
-	fpi     : 0
-	dlfeat  : 9
-	nawun   : 2047
-	nawupf  : 2047
-	nacwu   : 0
-	nabsn   : 2047
-	nabo    : 0
-	nabspf  : 2047
-	noiob   : 0
-	nvmcap  : 0
-	mssrl   : 0
-	mcl     : 0
-	msrc    : 0
-	anagrpid: 2
-	nsattr  : 0
-	nvmsetid: 0
-	endgid  : 0
-	nguid   : 507911ecda65a2498ccf0968009a5d07
-	eui64   : 0000000000000000
-	lbaf  0 : ms:0   lbads:9  rp:0 (in use)
-	 */
+		nvme id-ns /dev/nvme3n1 0x95
+		NVME Identify Namespace 149:
+		nsze    : 0x1000000
+		ncap    : 0x1000000
+		nuse    : 0x223b8
+		nsfeat  : 0xb
+		nlbaf   : 0
+		flbas   : 0
+		mc      : 0
+		dpc     : 0
+		dps     : 0
+		nmic    : 0x1
+		rescap  : 0xff
+		fpi     : 0
+		dlfeat  : 9
+		nawun   : 2047
+		nawupf  : 2047
+		nacwu   : 0
+		nabsn   : 2047
+		nabo    : 0
+		nabspf  : 2047
+		noiob   : 0
+		nvmcap  : 0
+		mssrl   : 0
+		mcl     : 0
+		msrc    : 0
+		anagrpid: 2
+		nsattr  : 0
+		nvmsetid: 0
+		endgid  : 0
+		nguid   : 507911ecda65a2498ccf0968009a5d07
+		eui64   : 0000000000000000
+		lbaf  0 : ms:0   lbads:9  rp:0 (in use)
+	*/
 
 	output, error := cmd.Output()
 	str := string(output)

--- a/gonvme_types.go
+++ b/gonvme_types.go
@@ -42,10 +42,10 @@ const (
 	NVMETransportNameRDMA NVMETransportName = "rdma"
 )
 
-// devicePathAndNamespace  defines the device path and namespace of a device
-type devicePathAndNamespace struct {
-	devicePath string
-	namespace  string
+// DevicePathAndNamespace  defines the device path and namespace of a device
+type DevicePathAndNamespace struct {
+	DevicePath string
+	Namespace  string
 }
 
 // NVMESession defines an iSCSI session info

--- a/gonvme_types.go
+++ b/gonvme_types.go
@@ -42,6 +42,12 @@ const (
 	NVMETransportNameRDMA NVMETransportName = "rdma"
 )
 
+// devicePathAndNamespace  defines the device path and namespace of a device
+type devicePathAndNamespace struct {
+	devicePath string
+	namespace  string
+}
+
 // NVMESession defines an iSCSI session info
 type NVMESession struct {
 	Target            string


### PR DESCRIPTION
# Description
The PR includes changes on the gonvme functions (ListNamespaceDevices and GetNamespaceData) to include the namespace in the output, which is required for the bugfix on Gobrick side.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/158|

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Tested on Linux environment with nvme library installed
- [x]  Changes on ListNamespaceDevices and GetNamespaceData are successful


Changes Done - Included the namespace in the output of both the function - ListNamespaceDevices and GetNamespaceData
```
ListNamespaceDevices Output - 
{devicePath namespace} [namespaceId1 namespaceId2]
{/dev/nvme0n1 54} [0x36 0x37]
{/dev/nvme0n2 55} [0x36 0x37]
{/dev/nvme1n1 54} [0x36 0x37]
{/dev/nvme1n2 55} [0x36 0x37]
```

Changes Made will be reflected for the bug caused in creating an NVMe pod with multiple volumes on the Gobrick side.

