### PR TITLE
Fix NVMe connections already exists for nvme cli version 2.0 and above

### DIFF
--- a/gonvme_tcp_fc.go
+++ b/gonvme_tcp_fc.go
@@ -483,6 +483,7 @@ func (nvme *NVMe) nvmeTCPConnect(target NVMeTarget, duplicateConnect bool) error
 			if nvmeConnectResult == 114 || nvmeConnectResult == 70 {
 				// session already exists
 				// do not treat this as a failure
+				// this is applicable if nvme cli version 1.16 or below 
 				if Output == "Failed to write to /dev/nvme-fabrics: Operation already in progress" || Output == "" {
 					log.Infof("NVMe connection already exists\n")
 					err = nil
@@ -490,6 +491,11 @@ func (nvme *NVMe) nvmeTCPConnect(target NVMeTarget, duplicateConnect bool) error
 					log.Errorf("\nError during nvme connect %s at %s: %v", target.TargetNqn, target.Portal, err)
 					return err
 				}
+			} else if nvmeConnectResult == 1 && strings.Contains(Output, "already connnected") {
+				// session already exists
+				// this is applicable if nvme cli version is 2.0 and above
+				log.Infof("NVMe connection already exists\n")
+				err = nil
 			} else {
 				log.Errorf("\nnvme connect failure: %v", err)
 			}
@@ -545,6 +551,7 @@ func (nvme *NVMe) nvmeFCConnect(target NVMeTarget, duplicateConnect bool) error 
 			if nvmeConnectResult == 114 || nvmeConnectResult == 70 {
 				// session already exists
 				// do not treat this as a failure
+				// this is applicable if nvme cli version 1.16 or below 
 				if Output == "Failed to write to /dev/nvme-fabrics: Operation already in progress" || Output == "" {
 					log.Infof("NVMe connection already exists\n")
 					err = nil
@@ -552,7 +559,12 @@ func (nvme *NVMe) nvmeFCConnect(target NVMeTarget, duplicateConnect bool) error 
 					log.Errorf("\nError during nvme connect %s at %s: %v", target.TargetNqn, target.Portal, err)
 					return err
 				}
-			} else {
+			} else if nvmeConnectResult == 1 && strings.Contains(Output, "already connnected") {
+				// session already exists
+				// this is applicable if nvme cli version is 2.0 and above
+				log.Infof("NVMe connection already exists\n")
+				err = nil
+			}  else {
 				log.Errorf("NVMe/FC connect failure: %v", err)
 			}
 		} else {

--- a/gonvme_tcp_fc.go
+++ b/gonvme_tcp_fc.go
@@ -483,7 +483,7 @@ func (nvme *NVMe) nvmeTCPConnect(target NVMeTarget, duplicateConnect bool) error
 			if nvmeConnectResult == 114 || nvmeConnectResult == 70 {
 				// session already exists
 				// do not treat this as a failure
-				// this is applicable if nvme cli version 1.16 or below 
+				// this is applicable if nvme cli version 1.16 or below
 				if Output == "Failed to write to /dev/nvme-fabrics: Operation already in progress" || Output == "" {
 					log.Infof("NVMe connection already exists\n")
 					err = nil
@@ -551,7 +551,7 @@ func (nvme *NVMe) nvmeFCConnect(target NVMeTarget, duplicateConnect bool) error 
 			if nvmeConnectResult == 114 || nvmeConnectResult == 70 {
 				// session already exists
 				// do not treat this as a failure
-				// this is applicable if nvme cli version 1.16 or below 
+				// this is applicable if nvme cli version 1.16 or below
 				if Output == "Failed to write to /dev/nvme-fabrics: Operation already in progress" || Output == "" {
 					log.Infof("NVMe connection already exists\n")
 					err = nil
@@ -564,7 +564,7 @@ func (nvme *NVMe) nvmeFCConnect(target NVMeTarget, duplicateConnect bool) error 
 				// this is applicable if nvme cli version is 2.0 and above
 				log.Infof("NVMe connection already exists\n")
 				err = nil
-			}  else {
+			} else {
 				log.Errorf("NVMe/FC connect failure: %v", err)
 			}
 		} else {


### PR DESCRIPTION
# Description
Fix NVMe connections already exists for nvme cli version 2.0 and above

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/885 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Tested with PowerStore on SLES SP4