### PR TITLE
Add ctrl-loss-tmo to connect commands

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -15,6 +15,18 @@ jobs:
         uses: dell/common-github-actions/go-code-formatter-linter-vetter@main
         with:
           directories: ./...
+  test:
+    name: Run Go unit tests and check package coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v4
+      - name: Run unit tests and check package coverage
+        uses: dell/common-github-actions/go-code-tester@main
+        with:
+          threshold: 16
+          test-folder: "./"
+          race-detector: "true"
   go_security_scan:
     name: Go security
     runs-on: ubuntu-latest

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -24,9 +24,10 @@ jobs:
       - name: Run unit tests and check package coverage
         uses: dell/common-github-actions/go-code-tester@main
         with:
-          threshold: 16
+          threshold: 19
           test-folder: "./"
           race-detector: "true"
+          run-test: "TestMock"
   go_security_scan:
     name: Go security
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@
 
 all:check int-test
 
-mock-test:
+unit-test:
 	go clean -cache
 	go test -v -coverprofile=c.out --run=TestMock
 

--- a/gonvme_tcp_fc.go
+++ b/gonvme_tcp_fc.go
@@ -528,9 +528,9 @@ func (nvme *NVMe) nvmeFCConnect(target NVMeTarget, duplicateConnect bool) error 
 	// D allows duplicate connections between same transport host and subsystem port
 	var exe []string
 	if duplicateConnect {
-		exe = nvme.buildNVMeCommand([]string{NVMeCommand, "connect", "-t", "fc", "-a", target.Portal, "-w", target.HostAdr, "-n", target.TargetNqn, "-D"})
+		exe = nvme.buildNVMeCommand([]string{NVMeCommand, "connect", "-t", "fc", "-a", target.Portal, "-w", target.HostAdr, "-n", target.TargetNqn, "--ctrl-loss-tmo=-1", "-D"})
 	} else {
-		exe = nvme.buildNVMeCommand([]string{NVMeCommand, "connect", "-t", "fc", "-a", target.Portal, "-w", target.HostAdr, "-n", target.TargetNqn})
+		exe = nvme.buildNVMeCommand([]string{NVMeCommand, "connect", "-t", "fc", "-a", target.Portal, "-w", target.HostAdr, "-n", target.TargetNqn, "--ctrl-loss-tmo=-1"})
 	}
 	cmd := exec.Command(exe[0], exe[1:]...) // #nosec G204
 	var Output string

--- a/gonvme_tcp_fc.go
+++ b/gonvme_tcp_fc.go
@@ -459,9 +459,9 @@ func (nvme *NVMe) nvmeTCPConnect(target NVMeTarget, duplicateConnect bool) error
 	// D allows duplicate connections between same transport host and subsystem port
 	var exe []string
 	if duplicateConnect {
-		exe = nvme.buildNVMeCommand([]string{NVMeCommand, "connect", "-t", "tcp", "-n", target.TargetNqn, "-a", target.Portal, "-s", NVMePort, "-D"})
+		exe = nvme.buildNVMeCommand([]string{NVMeCommand, "connect", "-t", "tcp", "-n", target.TargetNqn, "-a", target.Portal, "-s", NVMePort, "--ctrl-loss-tmo=-1", "-D"})
 	} else {
-		exe = nvme.buildNVMeCommand([]string{NVMeCommand, "connect", "-t", "tcp", "-n", target.TargetNqn, "-a", target.Portal, "-s", NVMePort})
+		exe = nvme.buildNVMeCommand([]string{NVMeCommand, "connect", "-t", "tcp", "-n", target.TargetNqn, "-a", target.Portal, "-s", NVMePort, "--ctrl-loss-tmo=-1"})
 	}
 	cmd := exec.Command(exe[0], exe[1:]...) // #nosec G204
 	var Output string


### PR DESCRIPTION
# Description
Added the option ctrl-loss-tmo=-1 so that PowerStore NDUs can take place without impacting the pod volume access. For 1.11.1 we are relying on the user setting this in across the NVMe module but we are asked to support this also in the connect command in case the user did not add the module option. See related GitHub issue 1459.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1459 |

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
