### PR TITLE
[bug-1770]: Return stderr in error response when failing NVMeTCPConnect

### DIFF
--- a/gonvme_tcp_fc.go
+++ b/gonvme_tcp_fc.go
@@ -523,9 +523,8 @@ func (nvme *NVMe) nvmeTCPConnect(target NVMeTarget, duplicateConnect bool) error
 		if exiterr, ok := err.(*exec.ExitError); ok {
 			// nvme connect exited with an exit code != 0
 			nvmeConnectResult := -1
-			if status, ok := exiterr.Sys().(syscall.WaitStatus); ok {
-				nvmeConnectResult = status.ExitStatus()
-			}
+			nvmeConnectResult = exiterr.ExitCode()
+
 			if nvmeConnectResult == 114 || nvmeConnectResult == 70 {
 				// session already exists
 				// do not treat this as a failure
@@ -534,8 +533,9 @@ func (nvme *NVMe) nvmeTCPConnect(target NVMeTarget, duplicateConnect bool) error
 					log.Infof("NVMe connection already exists\n")
 					err = nil
 				} else {
-					log.Errorf("\nError during nvme connect %s at %s: %v", target.TargetNqn, target.Portal, err)
-					return err
+					msg := fmt.Sprintf("error connecting to nvme target %s at %s: %v: %s", target.TargetNqn, target.Portal, err, Output)
+					log.Errorf("\n%s", msg)
+					return fmt.Errorf("%s", msg)
 				}
 			} else if nvmeConnectResult == 1 && strings.Contains(Output, NVMEAlreadyConnected) {
 				// session already exists
@@ -550,8 +550,9 @@ func (nvme *NVMe) nvmeTCPConnect(target NVMeTarget, duplicateConnect bool) error
 		}
 
 		if err != nil {
-			log.Errorf("\nError during nvme connect %s at %s: %v", target.TargetNqn, target.Portal, err)
-			return err
+			msg := fmt.Sprintf("error connecting to nvme target %s at %s: %v: %s", target.TargetNqn, target.Portal, err, Output)
+			log.Errorf("\n%s", msg)
+			return fmt.Errorf("%s", msg)
 		}
 	} else {
 		log.Infof("\nnvme connect successful: %s", target.TargetNqn)


### PR DESCRIPTION
# Description

Updates NVMeTCPConnect to return stderr in error responses for easier debugging.

Updates NVMeTCPConnect to use `ExitError.ExitCode()` to get the exit code instead of
```
if status, ok := exiterr.Sys().(syscall.WaitStatus); ok {
         nvmeConnectResult = status.ExitStatus()
}
```

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1770 |

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

Unit tests updated to verify content in error response.
