### PR TITLE
Support nvme-cli 2.11 (OCP 4.19, RHEL9.6, RCOS 9.6)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,4 @@
-#
-#
-# Copyright © 2022 Dell Inc. or its subsidiaries. All Rights Reserved.
+# Copyright © 2022-2025 Dell Inc. or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,15 +12,16 @@
 #
 #
 
+all: unit-test
 
-all:check int-test
+clean:
+	go clean -cache
 
 unit-test:
-	go clean -cache
-	go test -v -coverprofile=c.out
+	go test -v -count 1 -coverprofile=c.out
 
 int-test:
-		 go test -v -timeout 20m -coverprofile=c.out -coverpkg ./...
+	go test -v -timeout 20m -coverprofile=c.out -coverpkg ./...
 
 gocover:
 	go tool cover -html=c.out

--- a/gonvme_tcp_fc.go
+++ b/gonvme_tcp_fc.go
@@ -699,7 +699,7 @@ func (nvme *NVMe) ListNVMeDeviceAndNamespace() ([]DevicePathAndNamespace, error)
 
 						if hasNs && hasNsid {
 							devicePath := ns
-							if ! strings.HasPrefix(ns, "/dev/") {
+							if !strings.HasPrefix(ns, "/dev/") {
 								devicePath = "/dev/" + ns
 							}
 							pathAndNameSpace := DevicePathAndNamespace{
@@ -711,8 +711,6 @@ func (nvme *NVMe) ListNVMeDeviceAndNamespace() ([]DevicePathAndNamespace, error)
 					}
 				}
 			}
-
-			continue
 		} else {
 			// Releases prior to nvme-cli 2.11 use NameSpace and DevicePath.
 			device := unknownDevice.(map[string]interface{})

--- a/gonvme_tcp_fc.go
+++ b/gonvme_tcp_fc.go
@@ -723,11 +723,8 @@ func (nvme *NVMe) ListNVMeDeviceAndNamespace() ([]DevicePathAndNamespace, error)
 					DevicePath: devicePath,
 				}
 				result = append(result, pathAndNameSpace)
-				continue
 			}
 		}
-
-		log.Errorf("Device has an unrecognized format which we cannot handle: %v", unknownDevice)
 	}
 
 	return result, nil

--- a/gonvme_tcp_fc.go
+++ b/gonvme_tcp_fc.go
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright © 2022-2024 Dell Inc. or its subsidiaries. All Rights Reserved.
+ * Copyright © 2022-2025 Dell Inc. or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package gonvme
 
 import (
 	"bufio"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -25,6 +26,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"syscall"
 
@@ -658,46 +660,9 @@ func (nvme *NVMe) nvmeDisconnect(target NVMeTarget) error {
 	return err
 }
 
-// ListNVMeDeviceAndNamespace returns the NVME Device Paths and Namespace of each of the NVME device
+// ListNVMeDeviceAndNamespace returns the NVMe device paths and namespace of each of the NVMe device.
 func (nvme *NVMe) ListNVMeDeviceAndNamespace() ([]DevicePathAndNamespace, error) {
-	/* ListNVMeDeviceAndNamespace Output
-	{/dev/nvme0n1 54}
-	{/dev/nvme0n2 55}
-	{/dev/nvme1n1 54}
-	{/dev/nvme1n2 55}
-	*/
 	exe := nvme.buildNVMeCommand([]string{"nvme", "list", "-o", "json"})
-
-	/* nvme list -o json
-	{
-	  "Devices" : [
-	    {
-	      "NameSpace" : 9217,
-	      "DevicePath" : "/dev/nvme0n1",
-	      "Firmware" : "2.1.0.0",
-	      "Index" : 0,
-	      "ModelNumber" : "dellemc",
-	      "SerialNumber" : "FP08RZ2",
-	      "UsedBytes" : 0,
-	      "MaximumLBA" : 10485760,
-	      "PhysicalSize" : 5368709120,
-	      "SectorSize" : 512
-	    },
-	    {
-	      "NameSpace" : 9222,
-	      "DevicePath" : "/dev/nvme0n2",
-	      "Firmware" : "2.1.0.0",
-	      "Index" : 0,
-	      "ModelNumber" : "dellemc",
-	      "SerialNumber" : "FP08RZ2",
-	      "UsedBytes" : 0,
-	      "MaximumLBA" : 10485760,
-	      "PhysicalSize" : 5368709120,
-	      "SectorSize" : 512
-	    }
-	  ]
-	}
-	*/
 	cmd := getCommand(exe[0], exe[1:]...) // #nosec G204
 
 	output, err := cmd.Output()
@@ -705,41 +670,66 @@ func (nvme *NVMe) ListNVMeDeviceAndNamespace() ([]DevicePathAndNamespace, error)
 		return []DevicePathAndNamespace{}, err
 	}
 
-	str := string(output)
-	lines := strings.Split(str, "\n")
+	type NvmeResult struct {
+		Devices []interface{}
+	}
+
+	var nvmeResult NvmeResult
+	err = json.Unmarshal(output, &nvmeResult)
+	if err != nil {
+		log.Errorf("Could not unmarshal nvme list output: %v\nnvme list output: '%s'", err, output)
+		return []DevicePathAndNamespace{}, err
+	}
 
 	var result []DevicePathAndNamespace
-	var currentPathAndNamespace *DevicePathAndNamespace
-	var devicePath string
-	var namespace string
+	for _, unknownDevice := range nvmeResult.Devices {
+		// This format appears in nvme-cli 2.11. In this format the Namespace
+		// field has the device ID and the NSID is the namespace ID.
+		// See the UT for the different formats.
+		subsystems, hasSubsystems := unknownDevice.(map[string]interface{})["Subsystems"].([]interface{})
+		if hasSubsystems {
+			for _, subsystem := range subsystems {
+				subsystem := subsystem.(map[string]interface{})
+				namespaces, hasNamespaces := subsystem["Namespaces"].([]interface{})
+				if hasNamespaces {
+					for _, namespace := range namespaces {
+						namespace := namespace.(map[string]interface{})
+						ns, hasNs := namespace["NameSpace"].(string)
+						nsid, hasNsid := namespace["NSID"].(float64)
 
-	for _, line := range lines {
-
-		line = strings.ReplaceAll(strings.TrimSpace(line), ",", "")
-
-		switch {
-		case strings.HasPrefix(line, "\"NameSpace\""):
-			if len(strings.Split(line, ":")) >= 2 {
-				namespace = strings.ReplaceAll(strings.TrimSpace(strings.Split(line, ":")[1]), "\"", "")
+						if hasNs && hasNsid {
+							devicePath := ns
+							if ! strings.HasPrefix(ns, "/dev/") {
+								devicePath = "/dev/" + ns
+							}
+							pathAndNameSpace := DevicePathAndNamespace{
+								Namespace:  strconv.FormatFloat(float64(nsid), 'f', -1, 64),
+								DevicePath: devicePath,
+							}
+							result = append(result, pathAndNameSpace)
+						}
+					}
+				}
 			}
 
-		case strings.HasPrefix(line, "\"DevicePath\""):
-			if len(strings.Split(line, ":")) >= 2 {
-				devicePath = strings.ReplaceAll(strings.TrimSpace(strings.Split(line, ":")[1]), "\"", "")
+			continue
+		} else {
+			// Releases prior to nvme-cli 2.11 use NameSpace and DevicePath.
+			device := unknownDevice.(map[string]interface{})
+			nameSpace, hasNameSpace := device["NameSpace"].(float64)
+			devicePath, hasDevice := device["DevicePath"].(string)
 
-				PathAndNamespace := DevicePathAndNamespace{}
-				PathAndNamespace.Namespace = namespace
-				PathAndNamespace.DevicePath = devicePath
-
-				if currentPathAndNamespace != nil {
-					result = append(result, *currentPathAndNamespace)
+			if hasNameSpace && hasDevice {
+				pathAndNameSpace := DevicePathAndNamespace{
+					Namespace:  strconv.FormatFloat(float64(nameSpace), 'f', -1, 64),
+					DevicePath: devicePath,
 				}
-				currentPathAndNamespace = &PathAndNamespace
+				result = append(result, pathAndNameSpace)
+				continue
 			}
 		}
-	}
-	if currentPathAndNamespace != nil {
-		result = append(result, *currentPathAndNamespace)
+
+		log.Errorf("Device has an unrecognized format which we cannot handle: %v", unknownDevice)
 	}
 
 	return result, nil

--- a/gonvme_tcp_fc.go
+++ b/gonvme_tcp_fc.go
@@ -703,7 +703,7 @@ func (nvme *NVMe) ListNVMeDeviceAndNamespace() ([]DevicePathAndNamespace, error)
 								devicePath = "/dev/" + ns
 							}
 							pathAndNameSpace := DevicePathAndNamespace{
-								Namespace:  strconv.FormatFloat(float64(nsid), 'f', -1, 64),
+								Namespace:  strconv.FormatFloat(nsid, 'f', -1, 64),
 								DevicePath: devicePath,
 							}
 							result = append(result, pathAndNameSpace)
@@ -721,7 +721,7 @@ func (nvme *NVMe) ListNVMeDeviceAndNamespace() ([]DevicePathAndNamespace, error)
 
 			if hasNameSpace && hasDevice {
 				pathAndNameSpace := DevicePathAndNamespace{
-					Namespace:  strconv.FormatFloat(float64(nameSpace), 'f', -1, 64),
+					Namespace:  strconv.FormatFloat(nameSpace, 'f', -1, 64),
 					DevicePath: devicePath,
 				}
 				result = append(result, pathAndNameSpace)

--- a/gonvme_tcp_fc.go
+++ b/gonvme_tcp_fc.go
@@ -686,6 +686,31 @@ func (nvme *NVMe) ListNVMeDeviceAndNamespace() ([]DevicePathAndNamespace, error)
 		// This format appears in nvme-cli 2.11. In this format the Namespace
 		// field has the device ID and the NSID is the namespace ID.
 		// See the UT for the different formats.
+		//
+		//
+		// {
+		// 	"Devices":[
+		// 		{
+		// 		"HostNQN":"nqn.2014-08.org.nvmexpress:uuid:a66f1c42-4bce-a619-9c59-9ae6ac2ccb8a",
+		// 		"HostID":"a2d57d74-a198-4e6b-aa78-97af9cd00f31",
+		// 		"Subsystems":[
+		//          ...
+		// 			"Namespaces":[
+		// 				{
+		// 				"NameSpace":"nvme0n1",
+		// 				"Generic":"ng0n1",
+		// 				"NSID":293,
+		// 				"UsedBytes":620130304,
+		// 				"MaximumLBA":6291456,
+		// 				"PhysicalSize":3221225472,
+		// 				"SectorSize":512
+		// 				}
+		// 			]
+		// 			}
+		// 		]
+		// 		}
+		// 	]
+		// }
 		subsystems, hasSubsystems := unknownDevice.(map[string]interface{})["Subsystems"].([]interface{})
 		if hasSubsystems {
 			for _, subsystem := range subsystems {
@@ -713,6 +738,21 @@ func (nvme *NVMe) ListNVMeDeviceAndNamespace() ([]DevicePathAndNamespace, error)
 			}
 		} else {
 			// Releases prior to nvme-cli 2.11 use NameSpace and DevicePath.
+			// {
+			// 	"Devices" : [
+			// 	  {
+			// 		"NameSpace" : 9217,
+			// 		"DevicePath" : "/dev/nvme0n1",
+			// 		"Firmware" : "2.1.0.0",
+			// 		"Index" : 0,
+			// 		"ModelNumber" : "dellemc",
+			// 		"SerialNumber" : "FP08RZ2",
+			// 		"UsedBytes" : 0,
+			// 		"MaximumLBA" : 10485760,
+			// 		"PhysicalSize" : 5368709120,
+			// 		"SectorSize" : 512
+			// 	  }
+			//  ]
 			device := unknownDevice.(map[string]interface{})
 			nameSpace, hasNameSpace := device["NameSpace"].(float64)
 			devicePath, hasDevice := device["DevicePath"].(string)

--- a/gonvme_tcp_fc_test.go
+++ b/gonvme_tcp_fc_test.go
@@ -392,6 +392,65 @@ func TestListNVMeDeviceAndNamespace(t *testing.T) {
 			false,
 		},
 		{
+			"powermax devices",
+			func(_ string, _ ...string) command {
+				return &mockCommand{
+					out: []byte(`{
+						"Devices":[
+							{
+							"HostNQN":"nqn.2014-08.org.nvmexpress:uuid:6e791c42-7031-30e2-3342-732f51ca58ec",
+							"HostID":"a2d57d74-a198-4e6b-aa78-97af9cd00f31",
+							"Subsystems":[
+								{
+								"Subsystem":"nvme-subsys0",
+								"SubsystemNQN":"nqn.1988-11.com.dell:PowerMax_2500:00:000120001647",
+								"Controllers":[
+									{
+									"Controller":"nvme0",
+									"Cntlid":"17453",
+									"SerialNumber":"00000120001647",
+									"ModelNumber":"EMC PowerMax_2500",
+									"Firmware":"60790275",
+									"Transport":"tcp",
+									"Address":"traddr=10.11.12.13,trsvcid=4420,src_addr=10.10.10.21",
+									"Slot":"",
+									"Namespaces":[
+									],
+									"Paths":[
+										{
+										"Path":"nvme0c0n1",
+										"ANAState":"optimized"
+										}
+									]
+									}
+								],
+								"Namespaces":[
+									{
+									"NameSpace":"nvme0n1",
+									"Generic":"ng0n1",
+									"NSID":1874,
+									"UsedBytes":0,
+									"MaximumLBA":6293760,
+									"PhysicalSize":3222405120,
+									"SectorSize":512
+									}
+								]
+								}
+							]
+							}
+						]
+					  }`),
+				}
+			},
+			[]DevicePathAndNamespace{
+				{
+					DevicePath: "/dev/nvme0n1",
+					Namespace:  "1874",
+				},
+			},
+			false,
+		},
+		{
 			"error listing devices",
 			func(_ string, _ ...string) command {
 				return &mockCommand{

--- a/gonvme_tcp_fc_test.go
+++ b/gonvme_tcp_fc_test.go
@@ -261,7 +261,6 @@ func TestGetInitiators(t *testing.T) {
 // There are two known formats for the output of the nvme list -o json command.
 // Newer versions of nvme, around 2.11 (RHEL 9.6) introduced a version which is
 // incompatable with the older versions.
-//
 func TestListNVMeDeviceAndNamespace(t *testing.T) {
 	tests := []struct {
 		name         string


### PR DESCRIPTION
# Description
Support nvme-cli 2.11 which uses a different format in the `nvme list -o json` results. This release is used in OCP 4.19 and RHEL/RCOS 9.6 releases.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1896 |

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [X] I have verified that new and existing unit tests pass locally with my changes
- [X] I have not allowed coverage numbers to degenerate
- [X] I have maintained at least 90% code coverage
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [X] Tested provisioning and IO on OCP 4.18 using NVMeTCP protocol on PowerStore (regression)
- [X] Tested provisioning and IO on OCP 4.19 using NVMeTCP protocol on PowerStore (regression)
